### PR TITLE
feat: allow users to pass in additional props and export the type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "marquee",
-  "version": "1.0.0",
+  "name": "@devnomic/marquee",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "marquee",
-      "version": "1.0.0",
+      "name": "@devnomic/marquee",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
-import { HTMLAttributes, ReactNode } from 'react';
-import './global.css';
-import { cn } from './lib/utils';
+import { HTMLAttributes, ReactNode } from "react";
+import "./global.css";
+import { cn } from "./lib/utils";
 
 export type MarqueeProps = HTMLAttributes<HTMLDivElement> & {
   children: ReactNode;
-  direction?: 'left' | 'up';
+  direction?: "left" | "up";
   pauseOnHover?: boolean;
   reverse?: boolean;
   fade?: boolean;
@@ -14,7 +14,7 @@ export type MarqueeProps = HTMLAttributes<HTMLDivElement> & {
 
 export function Marquee({
   children,
-  direction = 'left',
+  direction = "left",
   pauseOnHover = false,
   reverse = false,
   fade = false,
@@ -26,19 +26,19 @@ export function Marquee({
   return (
     <div
       className={cn(
-        'group flex gap-[1rem] overflow-hidden',
-        direction === 'left' ? 'flex-row' : 'flex-col',
+        "group flex gap-[1rem] overflow-hidden",
+        direction === "left" ? "flex-row" : "flex-col",
         className
       )}
       style={{
         maskImage: fade
           ? `linear-gradient(${
-              direction === 'left' ? 'to right' : 'to bottom'
+              direction === "left" ? "to right" : "to bottom"
             }, transparent 0%, rgba(0, 0, 0, 1.0) 10%, rgba(0, 0, 0, 1.0) 90%, transparent 100%)`
           : undefined,
         WebkitMaskImage: fade
           ? `linear-gradient(${
-              direction === 'left' ? 'to right' : 'to bottom'
+              direction === "left" ? "to right" : "to bottom"
             }, transparent 0%, rgba(0, 0, 0, 1.0) 10%, rgba(0, 0, 0, 1.0) 90%, transparent 100%)`
           : undefined,
       }}
@@ -50,12 +50,12 @@ export function Marquee({
           <div
             key={i}
             className={cn(
-              'flex justify-around gap-[1rem] [--gap:1rem] shrink-0',
-              direction === 'left'
-                ? 'animate-marquee-left flex-row'
-                : 'animate-marquee-up flex-col',
-              pauseOnHover && 'group-hover:[animation-play-state:paused]',
-              reverse && 'direction-reverse',
+              "flex justify-around gap-[1rem] [--gap:1rem] shrink-0",
+              direction === "left"
+                ? "animate-marquee-left flex-row"
+                : "animate-marquee-up flex-col",
+              pauseOnHover && "group-hover:[animation-play-state:paused]",
+              reverse && "direction-reverse",
               innerClassName
             )}
           >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,45 +1,48 @@
-import { ReactNode } from "react";
-import "./global.css";
-import { cn } from "./lib/utils";
+import { HTMLAttributes, ReactNode } from 'react';
+import './global.css';
+import { cn } from './lib/utils';
+
+export type MarqueeProps = HTMLAttributes<HTMLDivElement> & {
+  children: ReactNode;
+  direction?: 'left' | 'up';
+  pauseOnHover?: boolean;
+  reverse?: boolean;
+  fade?: boolean;
+  innerClassName?: string;
+  numberOfCopies?: number;
+};
 
 export function Marquee({
   children,
-  direction = "left",
+  direction = 'left',
   pauseOnHover = false,
   reverse = false,
   fade = false,
   className,
   innerClassName,
   numberOfCopies = 2,
-}: {
-  children: ReactNode;
-  direction?: "left" | "up";
-  pauseOnHover?: boolean;
-  reverse?: boolean;
-  fade?: boolean;
-  className?: string;
-  innerClassName?: string;
-  numberOfCopies?: number;
-}) {
+  ...rest
+}: MarqueeProps) {
   return (
     <div
       className={cn(
-        "group flex gap-[1rem] overflow-hidden",
-        direction === "left" ? "flex-row" : "flex-col",
+        'group flex gap-[1rem] overflow-hidden',
+        direction === 'left' ? 'flex-row' : 'flex-col',
         className
       )}
       style={{
         maskImage: fade
           ? `linear-gradient(${
-              direction === "left" ? "to right" : "to bottom"
+              direction === 'left' ? 'to right' : 'to bottom'
             }, transparent 0%, rgba(0, 0, 0, 1.0) 10%, rgba(0, 0, 0, 1.0) 90%, transparent 100%)`
           : undefined,
         WebkitMaskImage: fade
           ? `linear-gradient(${
-              direction === "left" ? "to right" : "to bottom"
+              direction === 'left' ? 'to right' : 'to bottom'
             }, transparent 0%, rgba(0, 0, 0, 1.0) 10%, rgba(0, 0, 0, 1.0) 90%, transparent 100%)`
           : undefined,
       }}
+      {...rest}
     >
       {Array(numberOfCopies)
         .fill(0)
@@ -47,12 +50,12 @@ export function Marquee({
           <div
             key={i}
             className={cn(
-              "flex justify-around gap-[1rem] [--gap:1rem] shrink-0",
-              direction === "left"
-                ? "animate-marquee-left flex-row"
-                : "animate-marquee-up flex-col",
-              pauseOnHover && "group-hover:[animation-play-state:paused]",
-              reverse && "direction-reverse",
+              'flex justify-around gap-[1rem] [--gap:1rem] shrink-0',
+              direction === 'left'
+                ? 'animate-marquee-left flex-row'
+                : 'animate-marquee-up flex-col',
+              pauseOnHover && 'group-hover:[animation-play-state:paused]',
+              reverse && 'direction-reverse',
               innerClassName
             )}
           >


### PR DESCRIPTION
### Changes Made:

Added a MarqueeProps type that extends HTMLDivElement. The type includes additional props such as onChange to allow users to pass more custom props.

Exported the MarqueeProps type for users who may want to reference or extend it.

### Reasoning:

This change enhances the flexibility of the Marquee component, allowing users to pass a wider range of props, including native ones like `onChange`.

### Examples:

```tsx
// Example 1: Using additional props like onChange
<Marquee onChange={(event) => console.log('Marquee changed!', event)}>
  {/* ... */}
</Marquee>
```

```tsx
// Example 2: Reference or extend MarqueeProps
interface MyExtendedMarqueeProps extends MarqueeProps {
  customProp: string;
}

const MyExtendedMarquee: React.FC<MyExtendedMarqueeProps> = ({ customProp, ...rest }) => (
  <Marquee {...rest}>
    {/* ... */}
  </Marquee>
);
```